### PR TITLE
BUG: In myspy page, when I import an resume , we shall allow user import md file.

### DIFF
--- a/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
+++ b/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
@@ -16,7 +16,7 @@ namespace ResumeSpy.Infrastructure.Services
         private readonly ILogger<ResumeImportService> _logger;
 
         private static readonly HashSet<string> SupportedExtensions =
-            new(StringComparer.OrdinalIgnoreCase) { ".pdf", ".docx", ".doc", ".txt" };
+            new(StringComparer.OrdinalIgnoreCase) { ".pdf", ".docx", ".doc", ".txt", ".md" };
 
         public ResumeImportService(AIOrchestratorService aiOrchestrator, ILogger<ResumeImportService> logger)
         {
@@ -33,7 +33,7 @@ namespace ResumeSpy.Infrastructure.Services
             {
                 ".pdf"  => ExtractFromPdf(stream),
                 ".docx" or ".doc" => ExtractFromDocx(stream),
-                ".txt"  => await ExtractFromTxt(stream),
+                ".txt" or ".md"   => await ExtractFromTxt(stream),
                 _       => throw new NotSupportedException($"File type '{extension}' is not supported.")
             };
 

--- a/ResumeSpy.UI/Controllers/ResumeImportController.cs
+++ b/ResumeSpy.UI/Controllers/ResumeImportController.cs
@@ -11,7 +11,7 @@ namespace ResumeSpy.UI.Controllers
         private readonly ILogger<ResumeImportController> _logger;
 
         private static readonly HashSet<string> AllowedExtensions =
-            new(StringComparer.OrdinalIgnoreCase) { ".pdf", ".docx", ".doc", ".txt" };
+            new(StringComparer.OrdinalIgnoreCase) { ".pdf", ".docx", ".doc", ".txt", ".md" };
 
         private const long MaxFileSizeBytes = 10 * 1024 * 1024; // 10 MB
 
@@ -22,7 +22,7 @@ namespace ResumeSpy.UI.Controllers
         }
 
         /// <summary>
-        /// Accepts a resume file (PDF, DOCX, DOC, TXT) and returns the content
+        /// Accepts a resume file (PDF, DOCX, DOC, TXT, MD) and returns the content
         /// converted to structured Markdown by the AI provider.
         /// </summary>
         [HttpPost]
@@ -37,7 +37,7 @@ namespace ResumeSpy.UI.Controllers
 
             var ext = Path.GetExtension(file.FileName);
             if (!AllowedExtensions.Contains(ext))
-                return BadRequest(new { error = $"Unsupported file type '{ext}'. Allowed: PDF, DOCX, DOC, TXT." });
+                return BadRequest(new { error = $"Unsupported file type '{ext}'. Allowed: PDF, DOCX, DOC, TXT, MD." });
 
             try
             {


### PR DESCRIPTION
Closes #50 (frontend counterpart: feifeijin/ResumeSpyWeb#51)

## Summary
- Added `.md` to `AllowedExtensions` in `ResumeImportController` so the API no longer returns 400 for Markdown files
- Updated the 400 error message to list MD alongside PDF, DOCX, DOC, TXT
- Added `.md` to `SupportedExtensions` in `ResumeImportService`
- Routed `.md` to `ExtractFromTxt` in the switch expression — Markdown is plain text and requires no special parsing

## Test plan
- [ ] POST a `.md` resume file to `/api/resumeimport` — expect 200 with `markdown` and `suggestedTitle`
- [ ] POST a file with an unsupported extension — expect 400 with updated error listing MD
- [ ] Confirm existing PDF / DOCX / TXT imports still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)