### PR TITLE
BUG: We shall allow users to import files with all languages, md, pdf, doc, txt, etc.

### DIFF
--- a/ResumeSpy.Core/Interfaces/AI/IGenerativeTextService.cs
+++ b/ResumeSpy.Core/Interfaces/AI/IGenerativeTextService.cs
@@ -11,7 +11,8 @@ namespace ResumeSpy.Core.Interfaces.AI
         /// Generate a text response based on the provided request
         /// </summary>
         /// <param name="request">The AI request containing prompt and parameters</param>
+        /// <param name="cancellationToken">Token to cancel the in-flight HTTP call</param>
         /// <returns>The AI response with generated content and metadata</returns>
-        Task<AIResponse> GenerateResponseAsync(AIRequest request);
+        Task<AIResponse> GenerateResponseAsync(AIRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/ResumeSpy.Core/Interfaces/IServices/IResumeImportService.cs
+++ b/ResumeSpy.Core/Interfaces/IServices/IResumeImportService.cs
@@ -8,8 +8,9 @@ namespace ResumeSpy.Core.Interfaces.IServices
         /// </summary>
         /// <param name="stream">File content stream</param>
         /// <param name="extension">Lowercase file extension, e.g. ".pdf"</param>
+        /// <param name="cancellationToken">Propagated from the HTTP request; allows the caller to abort long-running AI calls</param>
         /// <returns>Markdown string and a suggested resume title</returns>
-        Task<ResumeImportResult> ImportAsync(Stream stream, string extension);
+        Task<ResumeImportResult> ImportAsync(Stream stream, string extension, CancellationToken cancellationToken = default);
     }
 
     public record ResumeImportResult(string Markdown, string SuggestedTitle);

--- a/ResumeSpy.Infrastructure/Prompts/ImportPrompts.cs
+++ b/ResumeSpy.Infrastructure/Prompts/ImportPrompts.cs
@@ -9,15 +9,15 @@ namespace ResumeSpy.Infrastructure.Prompts
             You are an expert resume formatter. Convert the provided resume text into clean, well-structured Markdown.
 
             Rules:
-            - Use # for the candidate's full name at the top
-            - Use ## for section headers: Summary, Experience, Education, Skills, etc.
+            - Use # for the candidate's full name at the top (preserve the original language — Chinese, Japanese, Korean, Arabic, etc.)
+            - Use ## for section headers (e.g. Summary, Experience, Education, Skills; translate these headers to English even if the content is in another language)
             - Use ### for job titles / company names within Experience
             - Use bullet points (-) for responsibilities and achievements
             - Preserve ALL factual data: names, dates, companies, education, contact info
             - Format contact info (email, phone, LinkedIn) as a single line under the name
             - Do NOT add, invent, or infer any information not present in the original
             - Return ONLY the Markdown — no preamble, no explanation, no code fences
-            - On the very last line, after a blank line, write: TITLE: <first name last name>'s Resume
+            - On the very last line, after a blank line, write: TITLE: <candidate full name>'s Resume
             """;
 
         internal static string BuildPrompt(string rawText) => $"""

--- a/ResumeSpy.Infrastructure/Properties/AssemblyInfo.cs
+++ b/ResumeSpy.Infrastructure/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+// Allow the test project to access internal members (e.g. ResumeImportService.DecodeText)
+// so encoding-detection logic can be unit-tested without making it public API.
+[assembly: InternalsVisibleTo("ResumeSpy.Tests")]

--- a/ResumeSpy.Infrastructure/Services/AI/AIOrchestratorService.cs
+++ b/ResumeSpy.Infrastructure/Services/AI/AIOrchestratorService.cs
@@ -35,7 +35,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
         /// <summary>
         /// Execute a text generation request with automatic provider selection and fallback
         /// </summary>
-        public async Task<AIResponse> ExecuteTextGenerationAsync(AIRequest request, bool useCache = true)
+        public async Task<AIResponse> ExecuteTextGenerationAsync(AIRequest request, bool useCache = true, CancellationToken cancellationToken = default)
         {
             // Generate cache key
             var cacheKey = useCache ? GenerateCacheKey(request) : null;
@@ -68,7 +68,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
                         continue;
                     }
 
-                    response = await service.GenerateResponseAsync(request);
+                    response = await service.GenerateResponseAsync(request, cancellationToken);
 
                     if (response.IsSuccess)
                     {

--- a/ResumeSpy.Infrastructure/Services/AI/HuggingFaceTextService.cs
+++ b/ResumeSpy.Infrastructure/Services/AI/HuggingFaceTextService.cs
@@ -43,7 +43,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
             return !string.IsNullOrWhiteSpace(value) ? value : throw new InvalidOperationException(errorMessage);
         }
 
-        public async Task<AIResponse> GenerateResponseAsync(AIRequest request)
+        public async Task<AIResponse> GenerateResponseAsync(AIRequest request, CancellationToken cancellationToken = default)
         {
             var stopwatch = Stopwatch.StartNew();
             var modelToUse = request.ModelId ?? _defaultModel;
@@ -63,7 +63,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
                 var json = JsonSerializer.Serialize(payload);
                 var content = new StringContent(json, Encoding.UTF8, System.Net.Mime.MediaTypeNames.Application.Json);
 
-                var response = await _httpClient.PostAsync(_endpoint, content);
+                var response = await _httpClient.PostAsync(_endpoint, content, cancellationToken);
 
                 // On rate-limit or model-loading errors, return failure immediately so the
                 // AIOrchestratorService can fall back to the next provider in the chain.

--- a/ResumeSpy.Infrastructure/Services/AI/OpenAITextService.cs
+++ b/ResumeSpy.Infrastructure/Services/AI/OpenAITextService.cs
@@ -45,7 +45,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
             return !string.IsNullOrWhiteSpace(value) ? value : throw new InvalidOperationException(errorMessage);
         }
 
-        public async Task<AIResponse> GenerateResponseAsync(AIRequest request)
+        public async Task<AIResponse> GenerateResponseAsync(AIRequest request, CancellationToken cancellationToken = default)
         {
             var stopwatch = Stopwatch.StartNew();
             var modelToUse = request.ModelId ?? _defaultModel;
@@ -55,12 +55,12 @@ namespace ResumeSpy.Infrastructure.Services.AI
                 var chatClient = _client.GetChatClient(modelToUse);
 
                 var messages = new List<ChatMessage>();
-                
+
                 if (!string.IsNullOrWhiteSpace(request.SystemMessage))
                 {
                     messages.Add(new SystemChatMessage(request.SystemMessage));
                 }
-                
+
                 messages.Add(new UserChatMessage(request.Prompt));
 
                 var options = new ChatCompletionOptions
@@ -69,7 +69,7 @@ namespace ResumeSpy.Infrastructure.Services.AI
                     MaxOutputTokenCount = request.MaxTokens
                 };
 
-                var completion = await chatClient.CompleteChatAsync(messages, options);
+                var completion = await chatClient.CompleteChatAsync(messages, options, cancellationToken);
 
                 stopwatch.Stop();
 

--- a/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
+++ b/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
@@ -24,17 +24,17 @@ namespace ResumeSpy.Infrastructure.Services
             _logger = logger;
         }
 
-        public async Task<ResumeImportResult> ImportAsync(Stream stream, string extension)
+        public async Task<ResumeImportResult> ImportAsync(Stream stream, string extension, CancellationToken cancellationToken = default)
         {
             if (!SupportedExtensions.Contains(extension))
                 throw new NotSupportedException($"File type '{extension}' is not supported.");
 
             var rawText = extension.ToLowerInvariant() switch
             {
-                ".pdf"  => ExtractFromPdf(stream),
+                ".pdf"            => ExtractFromPdf(stream),
                 ".docx" or ".doc" => ExtractFromDocx(stream),
-                ".txt" or ".md"   => await ExtractFromTxt(stream),
-                _       => throw new NotSupportedException($"File type '{extension}' is not supported.")
+                ".txt"  or ".md"  => await ExtractFromTxt(stream),
+                _                 => throw new NotSupportedException($"File type '{extension}' is not supported.")
             };
 
             if (string.IsNullOrWhiteSpace(rawText))
@@ -42,7 +42,7 @@ namespace ResumeSpy.Infrastructure.Services
 
             _logger.LogInformation("Extracted {Chars} chars from {Ext} file. Sending to AI.", rawText.Length, extension);
 
-            return await ConvertToMarkdownAsync(rawText);
+            return await ConvertToMarkdownAsync(rawText, cancellationToken);
         }
 
         private static string ExtractFromPdf(Stream stream)
@@ -72,11 +72,118 @@ namespace ResumeSpy.Infrastructure.Services
 
         private static async Task<string> ExtractFromTxt(Stream stream)
         {
-            using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
-            return await reader.ReadToEndAsync();
+            // Buffer the full stream so we can inspect the raw bytes for encoding detection.
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            var bytes = ms.ToArray();
+            return DecodeText(bytes);
         }
 
-        private async Task<ResumeImportResult> ConvertToMarkdownAsync(string rawText)
+        /// <summary>
+        /// Detects the encoding of a raw byte array and returns the decoded string.
+        /// Detection order:
+        /// 1. BOM markers (UTF-8, UTF-16 LE/BE) — most reliable
+        /// 2. Strict UTF-8 validation — covers the vast majority of modern files,
+        ///    including those with Chinese/Japanese/Korean content saved as UTF-8
+        /// 3. Language-aware CJK heuristic:
+        ///    — Each candidate encoding is tried with a strict (exception) fallback so
+        ///      only encodings that can fully decode the bytes are considered.
+        ///    — GB18030 and Shift-JIS byte ranges overlap, so a tiebreaker counts
+        ///      Hiragana + Katakana characters in the Shift-JIS decode: Japanese text
+        ///      almost always contains these syllabic scripts, while Chinese text does not.
+        ///    — Fallback priority: GB18030 → Shift-JIS → EUC-JP → EUC-KR
+        /// 4. Permissive UTF-8 as the last resort (invalid bytes → U+FFFD)
+        ///
+        /// Requires <c>Encoding.RegisterProvider(CodePagesEncodingProvider.Instance)</c>
+        /// to be called once at application startup (see Program.cs).
+        /// </summary>
+        internal static string DecodeText(byte[] bytes)
+        {
+            if (bytes.Length == 0) return string.Empty;
+
+            // ── BOM-based detection ──────────────────────────────────────────────
+            // UTF-8 BOM: EF BB BF
+            if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+                return Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+
+            // UTF-16 LE BOM: FF FE
+            if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+                return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+
+            // UTF-16 BE BOM: FE FF
+            if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+                return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+
+            // ── Strict UTF-8 (no BOM) ────────────────────────────────────────────
+            // This covers modern Chinese/Japanese/Korean files saved as UTF-8.
+            try
+            {
+                return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true)
+                    .GetString(bytes);
+            }
+            catch (DecoderFallbackException) { /* not valid UTF-8 – fall through */ }
+
+            // ── Legacy CJK encoding detection ────────────────────────────────────
+            // GB18030 and Shift-JIS byte ranges overlap: a Shift-JIS file may decode
+            // without errors under GB18030, but with completely different characters.
+            // We resolve the ambiguity by counting Hiragana / Katakana syllabics in
+            // the Shift-JIS result — Japanese text almost always contains them, Chinese
+            // text does not, so the winning encoding is unambiguous in practice.
+            var gb   = TryStrictDecode(bytes, "GB18030");
+            var sjis = TryStrictDecode(bytes, "shift_jis");
+
+            if (sjis != null && gb != null)
+            {
+                // Both can decode the bytes — decide by Japanese syllabic content.
+                if (CountJapaneseSyllabics(sjis) > CountJapaneseSyllabics(gb))
+                    return sjis;
+                // Otherwise Chinese (GB18030) is the better fit.
+                return gb;
+            }
+
+            if (gb   != null) return gb;
+            if (sjis != null) return sjis;
+
+            // EUC encodings as a last resort before the permissive fallback.
+            var eucJp = TryStrictDecode(bytes, "euc-jp");
+            if (eucJp != null) return eucJp;
+
+            var eucKr = TryStrictDecode(bytes, "euc-kr");
+            if (eucKr != null) return eucKr;
+
+            // ── Permissive UTF-8 fallback ────────────────────────────────────────
+            return Encoding.UTF8.GetString(bytes);
+        }
+
+        /// <summary>
+        /// Attempts to decode <paramref name="bytes"/> using <paramref name="encodingName"/>
+        /// with a strict error fallback. Returns <c>null</c> if the encoding is not
+        /// registered or if any byte sequence is invalid for that encoding.
+        /// </summary>
+        private static string? TryStrictDecode(byte[] bytes, string encodingName)
+        {
+            try
+            {
+                var enc = Encoding.GetEncoding(
+                    encodingName,
+                    new EncoderReplacementFallback("?"),
+                    new DecoderExceptionFallback());
+                return enc.GetString(bytes);
+            }
+            catch (DecoderFallbackException) { return null; }
+            catch (ArgumentException)        { return null; } // encoding not registered
+        }
+
+        /// <summary>
+        /// Counts Hiragana (U+3040–U+309F) and full-width Katakana (U+30A0–U+30FF)
+        /// characters in <paramref name="text"/>. A non-zero count is a strong signal
+        /// that the text is Japanese and should be decoded with Shift-JIS.
+        /// </summary>
+        private static int CountJapaneseSyllabics(string text) =>
+            text.Count(c => (c >= '぀' && c <= 'ゟ') ||
+                            (c >= '゠' && c <= 'ヿ'));
+
+        private async Task<ResumeImportResult> ConvertToMarkdownAsync(string rawText, CancellationToken cancellationToken)
         {
             var response = await _aiOrchestrator.ExecuteTextGenerationAsync(new AIRequest
             {
@@ -84,7 +191,7 @@ namespace ResumeSpy.Infrastructure.Services
                 SystemMessage = ImportPrompts.SystemMessage,
                 Temperature = 0.2,
                 MaxTokens = 4096,
-            }, useCache: false);
+            }, useCache: false, cancellationToken: cancellationToken);
 
             if (!response.IsSuccess || string.IsNullOrWhiteSpace(response.Content))
                 throw new InvalidOperationException($"AI conversion failed: {response.ErrorMessage}");

--- a/ResumeSpy.Tests/Services/ResumeImportEncodingTests.cs
+++ b/ResumeSpy.Tests/Services/ResumeImportEncodingTests.cs
@@ -1,0 +1,123 @@
+using ResumeSpy.Infrastructure.Services;
+using System.Text;
+using Xunit;
+
+namespace ResumeSpy.Tests.Services;
+
+/// <summary>
+/// Unit tests for ResumeImportService.DecodeText — the multi-encoding text detector
+/// that enables importing resumes in Chinese, Japanese, Korean, and other languages.
+/// </summary>
+public class ResumeImportEncodingTests
+{
+    public ResumeImportEncodingTests()
+    {
+        // Register code-page encodings (GBK, Shift-JIS, …) for the test process.
+        // Safe to call multiple times; subsequent calls are no-ops.
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    // ── UTF-8 (the common case) ──────────────────────────────────────────────
+
+    [Fact]
+    public void DecodeText_EmptyBytes_ReturnsEmptyString()
+    {
+        Assert.Equal(string.Empty, ResumeImportService.DecodeText([]));
+    }
+
+    [Fact]
+    public void DecodeText_Utf8NoBom_DecodesCorrectly()
+    {
+        // Modern editors save Chinese/Japanese as UTF-8 without BOM.
+        const string text = "Hello, 世界! こんにちは!";
+        var bytes = new UTF8Encoding(false).GetBytes(text);
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    [Fact]
+    public void DecodeText_Utf8WithBom_StripsAndDecodesCorrectly()
+    {
+        const string text = "Résumé – 简历 – 履歴書";
+        var utf8Bom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+        var bytes = utf8Bom.GetBytes(text); // starts with EF BB BF
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    [Fact]
+    public void DecodeText_Ascii_DecodesCorrectly()
+    {
+        const string text = "John Doe\nSoftware Engineer";
+        var bytes = Encoding.ASCII.GetBytes(text);
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    // ── UTF-16 (Windows Notepad default in older Windows) ────────────────────
+
+    [Fact]
+    public void DecodeText_Utf16LeBom_DecodesCorrectly()
+    {
+        const string text = "こんにちは世界";
+        // Encoding.Unicode == UTF-16 LE; GetBytes includes the BOM preamble when
+        // using the static property but NOT when constructing via new UnicodeEncoding().
+        // We build the expected byte layout explicitly.
+        var preamble = Encoding.Unicode.GetPreamble(); // FF FE
+        var body = Encoding.Unicode.GetBytes(text);
+        var bytes = preamble.Concat(body).ToArray();
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    [Fact]
+    public void DecodeText_Utf16BeBom_DecodesCorrectly()
+    {
+        const string text = "안녕하세요";
+        var preamble = Encoding.BigEndianUnicode.GetPreamble(); // FE FF
+        var body = Encoding.BigEndianUnicode.GetBytes(text);
+        var bytes = preamble.Concat(body).ToArray();
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    // ── Legacy CJK encodings ─────────────────────────────────────────────────
+
+    [Fact]
+    public void DecodeText_Gb18030_DecodesSimplifiedChinese()
+    {
+        // GB18030 is a superset of GBK / GB2312 — the dominant Chinese encoding
+        // used by Windows tools before UTF-8 became widespread.
+        const string text = "你好，我的名字是张伟。";
+        var gb = Encoding.GetEncoding("GB18030");
+        var bytes = gb.GetBytes(text);
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    [Fact]
+    public void DecodeText_ShiftJis_DecodesJapanese()
+    {
+        // Shift-JIS is the legacy Japanese encoding produced by many Windows and
+        // macOS apps when a Japanese locale is active.
+        const string text = "田中太郎のレジュメ";
+        var sjis = Encoding.GetEncoding("shift_jis");
+        var bytes = sjis.GetBytes(text);
+
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+
+    // ── Correctness: UTF-8 is preferred over CJK when both would match ───────
+
+    [Fact]
+    public void DecodeText_ChineseUtf8_DoesNotMisdetectAsGb18030()
+    {
+        // A UTF-8 file with Chinese characters must be decoded as UTF-8, not GB18030,
+        // because the byte sequences overlap but have different interpretations.
+        const string text = "软件工程师";
+        var bytes = new UTF8Encoding(false).GetBytes(text);
+
+        // The result must still equal the original Chinese string.
+        Assert.Equal(text, ResumeImportService.DecodeText(bytes));
+    }
+}

--- a/ResumeSpy.UI/Controllers/ResumeImportController.cs
+++ b/ResumeSpy.UI/Controllers/ResumeImportController.cs
@@ -7,6 +7,10 @@ namespace ResumeSpy.UI.Controllers
     [Route("api/[controller]")]
     public class ResumeImportController : ControllerBase
     {
+        // Reasonable upper-bound for file extraction + AI processing, even for large
+        // multi-page resumes in CJK languages (which produce more tokens than Latin text).
+        private static readonly TimeSpan ImportTimeout = TimeSpan.FromSeconds(120);
+
         private readonly IResumeImportService _importService;
         private readonly ILogger<ResumeImportController> _logger;
 
@@ -24,10 +28,11 @@ namespace ResumeSpy.UI.Controllers
         /// <summary>
         /// Accepts a resume file (PDF, DOCX, DOC, TXT, MD) and returns the content
         /// converted to structured Markdown by the AI provider.
+        /// Supports files in any language including Chinese, Japanese, Korean, etc.
         /// </summary>
         [HttpPost]
         [RequestSizeLimit(10 * 1024 * 1024)]
-        public async Task<ActionResult> Import(IFormFile file)
+        public async Task<ActionResult> Import(IFormFile file, CancellationToken cancellationToken)
         {
             if (file == null || file.Length == 0)
                 return BadRequest(new { error = "No file provided." });
@@ -39,16 +44,29 @@ namespace ResumeSpy.UI.Controllers
             if (!AllowedExtensions.Contains(ext))
                 return BadRequest(new { error = $"Unsupported file type '{ext}'. Allowed: PDF, DOCX, DOC, TXT, MD." });
 
+            // Link the client-disconnect token with our own deadline so that long-running
+            // AI calls are cancelled promptly regardless of which signal fires first.
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(ImportTimeout);
+
             try
             {
                 using var stream = file.OpenReadStream();
-                var result = await _importService.ImportAsync(stream, ext);
+                var result = await _importService.ImportAsync(stream, ext, cts.Token);
 
                 return Ok(new
                 {
                     markdown = result.Markdown,
                     suggestedTitle = result.SuggestedTitle,
                 });
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                // Our deadline fired before the client disconnected.
+                _logger.LogWarning(
+                    "Resume import timed out after {Seconds}s for file '{Name}'.",
+                    (int)ImportTimeout.TotalSeconds, file.FileName);
+                return StatusCode(504, new { error = $"The request timed out after {(int)ImportTimeout.TotalSeconds} seconds. Please try again or upload a smaller file." });
             }
             catch (NotSupportedException ex)
             {

--- a/ResumeSpy.UI/Program.cs
+++ b/ResumeSpy.UI/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,9 @@ using ResumeSpy.Infrastructure.Configuration;
 using ResumeSpy.Core.Entities.General;
 using ResumeSpy.UI.Swagger;
 
+// Enable non-UTF-8 encodings (GBK, Shift-JIS, EUC-JP, EUC-KR, …) so the
+// resume import service can read legacy CJK text files without byte loss.
+Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
Closes #13

## Summary

- **CJK encoding detection for `.txt`/`.md` files**: replaced the UTF-8-only `StreamReader` with a layered detector that handles UTF-8 BOM, UTF-16 LE/BE BOM, strict UTF-8 (no BOM), GB18030 / GBK (Chinese), Shift-JIS (Japanese), EUC-JP, and EUC-KR. A Hiragana/Katakana syllabic count breaks the GB18030 ↔ Shift-JIS tie correctly, since Japanese text almost always contains these scripts.
- **Request timeout**: `ResumeImportController` now enforces a 120 s deadline (linked to the client-disconnect token) and returns HTTP 504 with a clear message when it fires, preventing the endpoint from hanging indefinitely on large CJK resumes.
- **CancellationToken propagation**: the token flows end-to-end from the controller → `IResumeImportService` → `AIOrchestratorService` → both AI provider `HttpClient`/SDK calls, so cancellation actually aborts in-flight HTTP requests.
- **Language-agnostic AI prompt**: the import system prompt no longer assumes a Western first/last-name format for the `TITLE:` line.
- **`CodePagesEncodingProvider` registration**: called once at startup in `Program.cs` so all CJK code-page encodings are available at runtime.

## Test plan

- [x] All 74 existing tests pass
- [x] 9 new unit tests in `ResumeImportEncodingTests` cover: empty bytes, ASCII, UTF-8 no BOM (CJK), UTF-8 BOM, UTF-16 LE BOM, UTF-16 BE BOM, GB18030 (Simplified Chinese), Shift-JIS (Japanese), and the UTF-8-takes-priority-over-GB18030 case

🤖 Generated with [Claude Code](https://claude.com/claude-code)