### PR TITLE
BUG： When import from MD files, I want to keep the original format of it. Do not convert anything.

### DIFF
--- a/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
+++ b/ResumeSpy.Infrastructure/Services/ResumeImportService.cs
@@ -40,6 +40,12 @@ namespace ResumeSpy.Infrastructure.Services
             if (string.IsNullOrWhiteSpace(rawText))
                 throw new InvalidOperationException("No readable text found in the uploaded file.");
 
+            if (extension.Equals(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("Extracted {Chars} chars from .md file. Returning as-is.", rawText.Length);
+                return new ResumeImportResult(rawText, ExtractMarkdownTitle(rawText));
+            }
+
             _logger.LogInformation("Extracted {Chars} chars from {Ext} file. Sending to AI.", rawText.Length, extension);
 
             return await ConvertToMarkdownAsync(rawText, cancellationToken);
@@ -197,6 +203,14 @@ namespace ResumeSpy.Infrastructure.Services
         private static int CountJapaneseSyllabics(string text) =>
             text.Count(c => (c >= '぀' && c <= 'ゟ') ||
                             (c >= '゠' && c <= 'ヿ'));
+
+        private static string ExtractMarkdownTitle(string markdown)
+        {
+            var heading = markdown.Split('\n')
+                .Select(l => l.Trim())
+                .FirstOrDefault(l => l.StartsWith("# "));
+            return heading != null ? heading[2..].Trim() : "Imported Resume";
+        }
 
         private async Task<ResumeImportResult> ConvertToMarkdownAsync(string rawText, CancellationToken cancellationToken)
         {

--- a/ResumeSpy.Tests/Services/ResumeImportMarkdownTests.cs
+++ b/ResumeSpy.Tests/Services/ResumeImportMarkdownTests.cs
@@ -1,0 +1,51 @@
+using ResumeSpy.Infrastructure.Services;
+using System.Reflection;
+using Xunit;
+
+namespace ResumeSpy.Tests.Services;
+
+public class ResumeImportMarkdownTests
+{
+    // ── ExtractMarkdownTitle ─────────────────────────────────────────────────
+
+    private static string InvokeExtractMarkdownTitle(string markdown)
+    {
+        var method = typeof(ResumeImportService)
+            .GetMethod("ExtractMarkdownTitle", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, [markdown])!;
+    }
+
+    [Fact]
+    public void ExtractMarkdownTitle_WithH1Heading_ReturnsHeadingText()
+    {
+        const string markdown = "# John Doe\n\n## Experience\n- Software Engineer";
+        Assert.Equal("John Doe", InvokeExtractMarkdownTitle(markdown));
+    }
+
+    [Fact]
+    public void ExtractMarkdownTitle_WithNoH1Heading_ReturnsDefault()
+    {
+        const string markdown = "## Experience\n- Software Engineer";
+        Assert.Equal("Imported Resume", InvokeExtractMarkdownTitle(markdown));
+    }
+
+    [Fact]
+    public void ExtractMarkdownTitle_WithMultipleH1Headings_ReturnsFirst()
+    {
+        const string markdown = "# Alice\n# Bob\n## Skills";
+        Assert.Equal("Alice", InvokeExtractMarkdownTitle(markdown));
+    }
+
+    [Fact]
+    public void ExtractMarkdownTitle_EmptyString_ReturnsDefault()
+    {
+        Assert.Equal("Imported Resume", InvokeExtractMarkdownTitle(string.Empty));
+    }
+
+    [Fact]
+    public void ExtractMarkdownTitle_H1WithLeadingWhitespace_ReturnsHeadingText()
+    {
+        const string markdown = "   # Jane Smith\n\n## Education";
+        Assert.Equal("Jane Smith", InvokeExtractMarkdownTitle(markdown));
+    }
+}


### PR DESCRIPTION
Closes #19

## Summary
- `.md` files are now returned as-is without passing through AI conversion, preserving the original markdown formatting exactly
- Title is extracted from the first `# ` heading in the file, falling back to "Imported Resume"
- Added unit tests for the title extraction logic

## Test plan
- [x] All 87 existing tests pass
- [x] New tests cover title extraction: with H1, without H1, multiple H1s, empty string, leading whitespace