### PR TITLE
Redact JWTs/PII in request-response logging; set prod log level to Warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ Scripts/LocalDev/
 *.env
 !.env.example
 
-# Production config (secrets injected at deploy time)
-ResumeSpy.UI/appsettings.Production.json
+# Production secrets are injected at deploy time via environment variables.
+# appsettings.Production.json is tracked for non-secret config (e.g. log levels).
 
 # Local/Dev environment files
 .env.local

--- a/ResumeSpy.Tests/Middlewares/RequestResponseLoggingMiddlewareTests.cs
+++ b/ResumeSpy.Tests/Middlewares/RequestResponseLoggingMiddlewareTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ResumeSpy.UI.Middlewares;
+using Xunit;
+
+namespace ResumeSpy.Tests.Middlewares;
+
+public class RequestResponseLoggingMiddlewareTests
+{
+    private sealed class CaptureLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+
+    [Theory]
+    [InlineData("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.secret.sig")]
+    [InlineData("Cookie", "session=abc123; token=xyz")]
+    [InlineData("Set-Cookie", "session=abc123; HttpOnly")]
+    [InlineData("X-API-Key", "sk-secret-key-12345")]
+    [InlineData("X-Auth-Token", "very-secret-token")]
+    public async Task Invoke_RedactsSensitiveRequestHeaders(string headerName, string sensitiveValue)
+    {
+        var logger = new CaptureLogger<RequestResponseLoggingMiddleware>();
+        var middleware = new RequestResponseLoggingMiddleware(_ => Task.CompletedTask, logger);
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/test";
+        context.Request.Headers[headerName] = sensitiveValue;
+
+        await middleware.Invoke(context);
+
+        var allLogs = string.Join("\n", logger.Messages);
+        Assert.DoesNotContain(sensitiveValue, allLogs, StringComparison.Ordinal);
+        Assert.Contains("[REDACTED]", allLogs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Invoke_LogsNonSensitiveHeaders()
+    {
+        var logger = new CaptureLogger<RequestResponseLoggingMiddleware>();
+        var middleware = new RequestResponseLoggingMiddleware(_ => Task.CompletedTask, logger);
+        var context = new DefaultHttpContext();
+        context.Request.Method = "POST";
+        context.Request.Path = "/api/resume";
+        context.Request.Headers["Content-Type"] = "application/json";
+
+        await middleware.Invoke(context);
+
+        var allLogs = string.Join("\n", logger.Messages);
+        Assert.Contains("application/json", allLogs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Invoke_LogsMethodPathAndStatusCode()
+    {
+        var logger = new CaptureLogger<RequestResponseLoggingMiddleware>();
+        var middleware = new RequestResponseLoggingMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        }, logger);
+        var context = new DefaultHttpContext();
+        context.Request.Method = "GET";
+        context.Request.Path = "/api/resume";
+
+        await middleware.Invoke(context);
+
+        var allLogs = string.Join("\n", logger.Messages);
+        Assert.Contains("GET", allLogs, StringComparison.Ordinal);
+        Assert.Contains("/api/resume", allLogs, StringComparison.Ordinal);
+        Assert.Contains("200", allLogs, StringComparison.Ordinal);
+    }
+}

--- a/ResumeSpy.UI/Middlewares/RequestResponseLoggingMiddleware.cs
+++ b/ResumeSpy.UI/Middlewares/RequestResponseLoggingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿namespace ResumeSpy.UI.Middlewares
+namespace ResumeSpy.UI.Middlewares
 {
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Http;
@@ -7,6 +7,16 @@
 
     public class RequestResponseLoggingMiddleware
     {
+        // Headers that carry credentials or session tokens and must never appear in logs.
+        private static readonly HashSet<string> SensitiveHeaders = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Authorization",
+            "Cookie",
+            "Set-Cookie",
+            "X-API-Key",
+            "X-Auth-Token",
+        };
+
         private readonly RequestDelegate _next;
         private readonly ILogger<RequestResponseLoggingMiddleware> _logger;
 
@@ -18,37 +28,32 @@
 
         public async Task Invoke(HttpContext context)
         {
-            // Log the incoming request
             LogRequest(context.Request);
-
-
-            // Call the next middleware in the pipeline
             await _next(context);
-
-            // Log the outgoing response
             LogResponse(context.Response);
         }
 
         private void LogRequest(HttpRequest request)
         {
-            _logger.LogInformation($"Request received: {request.Method} {request.Path}");
-            _logger.LogInformation($"Request headers: {GetHeadersAsString(request.Headers)}");
+            _logger.LogInformation("Request: {Method} {Path}", request.Method, request.Path);
+            _logger.LogDebug("Request headers: {Headers}", GetHeadersAsString(request.Headers));
         }
 
         private void LogResponse(HttpResponse response)
         {
-            _logger.LogInformation($"Response sent: {response.StatusCode}");
-            _logger.LogInformation($"Response headers: {GetHeadersAsString(response.Headers)}");
+            _logger.LogInformation("Response: {StatusCode}", response.StatusCode);
+            _logger.LogDebug("Response headers: {Headers}", GetHeadersAsString(response.Headers));
         }
 
-        private string GetHeadersAsString(IHeaderDictionary headers)
+        private static string GetHeadersAsString(IHeaderDictionary headers)
         {
-            var stringBuilder = new StringBuilder();
+            var sb = new StringBuilder();
             foreach (var (key, value) in headers)
             {
-                stringBuilder.AppendLine($"{key}: {value}");
+                var displayValue = SensitiveHeaders.Contains(key) ? "[REDACTED]" : value.ToString();
+                sb.AppendLine($"{key}: {displayValue}");
             }
-            return stringBuilder.ToString();
+            return sb.ToString();
         }
     }
 
@@ -60,5 +65,4 @@
             return builder.UseMiddleware<RequestResponseLoggingMiddleware>();
         }
     }
-
 }

--- a/ResumeSpy.UI/appsettings.Production.json
+++ b/ResumeSpy.UI/appsettings.Production.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
Closes #29

## Summary
- **Redact sensitive headers**: `Authorization`, `Cookie`, `Set-Cookie`, `X-API-Key`, `X-Auth-Token` are replaced with `[REDACTED]` in all log output — JWT bearer tokens and session cookies can no longer leak into logs.
- **Move header dumps to `LogDebug`**: Verbose header logging is downgraded from `LogInformation` → `LogDebug`, so it is suppressed at `Information` level and above. Method/path/status remain at `LogInformation` for basic observability.
- **Structured logging**: Replaced string interpolation with message templates (`{Method}`, `{Path}`, `{StatusCode}`, `{Headers}`) for proper semantic logging.
- **Production log level**: Added `appsettings.Production.json` setting `Default` and `Microsoft.AspNetCore` to `Warning`, matching the documented intent. Removed the file from `.gitignore` (no secrets in this file; prod secrets are injected via environment variables at deploy time).

## Test plan
- [x] `RequestResponseLoggingMiddlewareTests` — theory covering all five sensitive header names, plus non-sensitive header pass-through and method/path/status code logging.
- [x] All 102 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)