### PR TITLE
fix: BUG: Login Failed

### DIFF
--- a/ResumeSpy.Tests/Middlewares/EnsureLocalUserMiddlewareTests.cs
+++ b/ResumeSpy.Tests/Middlewares/EnsureLocalUserMiddlewareTests.cs
@@ -1,0 +1,110 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ResumeSpy.Core.Entities.General;
+using ResumeSpy.Core.Interfaces.Services;
+using ResumeSpy.UI.Middlewares;
+using Xunit;
+
+namespace ResumeSpy.Tests.Middlewares;
+
+public class EnsureLocalUserMiddlewareTests
+{
+    private readonly Mock<IIdentityLinkingService> _identityService = new();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private readonly Mock<ILogger<EnsureLocalUserMiddleware>> _logger = new();
+
+    private HttpContext BuildContext(bool isAuthenticated, string? sub = "user-123", string? email = "user@example.com")
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+
+        if (isAuthenticated)
+        {
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, sub!),
+                new("email", email ?? string.Empty),
+            };
+            context.User = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        }
+
+        return context;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_PassesThrough_WhenUserIsUnauthenticated()
+    {
+        var nextCalled = false;
+        var middleware = new EnsureLocalUserMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var context = BuildContext(isAuthenticated: false);
+
+        await middleware.InvokeAsync(context, _identityService.Object, _cache, _logger.Object);
+
+        Assert.True(nextCalled);
+        _identityService.Verify(s => s.ResolveUserAsync(It.IsAny<AuthCallbackContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SetsEffectiveUserId_WhenIdentityResolved()
+    {
+        var user = new ApplicationUser { Id = "local-user-1", Email = "user@example.com" };
+        _identityService
+            .Setup(s => s.ResolveUserAsync(It.IsAny<AuthCallbackContext>()))
+            .ReturnsAsync(new IdentityLinkingResult(user, IsNewUser: false, IsNewIdentityLinked: false));
+
+        var middleware = new EnsureLocalUserMiddleware(_ => Task.CompletedTask);
+        var context = BuildContext(isAuthenticated: true, sub: "supabase-uuid-1");
+
+        await middleware.InvokeAsync(context, _identityService.Object, _cache, _logger.Object);
+
+        Assert.Equal("local-user-1", context.Items["EffectiveUserId"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_UsesCache_OnSecondRequest()
+    {
+        var user = new ApplicationUser { Id = "local-user-1", Email = "user@example.com" };
+        _identityService
+            .Setup(s => s.ResolveUserAsync(It.IsAny<AuthCallbackContext>()))
+            .ReturnsAsync(new IdentityLinkingResult(user, IsNewUser: false, IsNewIdentityLinked: false));
+
+        var middleware = new EnsureLocalUserMiddleware(_ => Task.CompletedTask);
+
+        var ctx1 = BuildContext(isAuthenticated: true, sub: "supabase-uuid-1");
+        await middleware.InvokeAsync(ctx1, _identityService.Object, _cache, _logger.Object);
+
+        var ctx2 = BuildContext(isAuthenticated: true, sub: "supabase-uuid-1");
+        await middleware.InvokeAsync(ctx2, _identityService.Object, _cache, _logger.Object);
+
+        // Service called only once; second request served from cache
+        _identityService.Verify(s => s.ResolveUserAsync(It.IsAny<AuthCallbackContext>()), Times.Once);
+        Assert.Equal("local-user-1", ctx2.Items["EffectiveUserId"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Returns500WithJsonBody_WhenIdentityResolutionFails()
+    {
+        _identityService
+            .Setup(s => s.ResolveUserAsync(It.IsAny<AuthCallbackContext>()))
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+
+        var nextCalled = false;
+        var middleware = new EnsureLocalUserMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+        var context = BuildContext(isAuthenticated: true);
+
+        await middleware.InvokeAsync(context, _identityService.Object, _cache, _logger.Object);
+
+        Assert.False(nextCalled);
+        Assert.Equal(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
+        Assert.StartsWith("application/json", context.Response.ContentType);
+
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        var body = await JsonDocument.ParseAsync(context.Response.Body);
+        Assert.False(body.RootElement.GetProperty("succeeded").GetBoolean());
+        Assert.NotEmpty(body.RootElement.GetProperty("errors").EnumerateArray());
+    }
+}

--- a/ResumeSpy.UI/Middlewares/EnsureLocalUserMiddleware.cs
+++ b/ResumeSpy.UI/Middlewares/EnsureLocalUserMiddleware.cs
@@ -70,6 +70,12 @@ namespace ResumeSpy.UI.Middlewares
                         {
                             logger.LogError(ex, "IdentityLinkingService failed for {Provider}/{ProviderUserId}", provider, providerUserId);
                             context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                            context.Response.ContentType = "application/json";
+                            await context.Response.WriteAsJsonAsync(new
+                            {
+                                succeeded = false,
+                                errors = new[] { "Failed to resolve user identity." }
+                            });
                             return;
                         }
                     }

--- a/ResumeSpy.UI/Program.cs
+++ b/ResumeSpy.UI/Program.cs
@@ -127,8 +127,11 @@ builder.Services.Configure<SupabaseSettings>(builder.Configuration.GetSection("S
 builder.Services.Configure<AnonymousUserSettings>(builder.Configuration.GetSection("AnonymousUserSettings"));
 
 // Supabase JWT validation
-var supabaseUrl = builder.Configuration["Supabase:Url"]
-    ?? throw new InvalidOperationException("Supabase:Url is not configured.");
+var supabaseUrl = builder.Configuration["Supabase:Url"];
+if (string.IsNullOrWhiteSpace(supabaseUrl))
+    throw new InvalidOperationException(
+        "Supabase:Url is not configured. Set the SUPABASE_URL environment variable.");
+supabaseUrl = supabaseUrl.TrimEnd('/');
 
 // Use the JwtBearer Authority/OIDC discovery to fetch and cache JWKS lazily.
 // The handler refreshes signing keys automatically, so Supabase JWT key


### PR DESCRIPTION
## Summary

Closes #51

- **Root cause – empty/trailing-slash Supabase URL breaks all JWT validation**: `Program.cs` used a `?? throw` null check on `Supabase:Url`, which passes through an empty string (the appsettings.json default). An empty URL produces authority `"/auth/v1"` (relative), making OIDC discovery fail for every request. A trailing slash (e.g. `SUPABASE_URL=https://host/`) produces `"https://host//auth/v1"`, mismatching the `iss` claim in every Supabase JWT and rejecting all tokens. Both cases cause all three auth methods (magic link, Google, GitHub) to fail simultaneously.
- **Fix**: replace the null check with `IsNullOrWhiteSpace` + `TrimEnd('/')`, matching the pattern already used in `ImageGenerationService` (line 55).
- **Bonus**: `EnsureLocalUserMiddleware` previously returned a bare 500 with no body on failure; it now writes `application/json` so clients and logs can identify auth middleware errors rather than seeing a silent empty response.
- **Tests**: 4 new unit tests for `EnsureLocalUserMiddleware` covering pass-through (unauthenticated), happy path, cache hit, and the JSON-500 error path.

## Test plan

- [ ] Verify all 106 tests pass (`dotnet test`)
- [ ] Set `SUPABASE_URL` to an empty string locally — confirm startup throws `InvalidOperationException` with a clear message
- [ ] Set `SUPABASE_URL=https://yourproject.supabase.co/` (trailing slash) — confirm `supabaseAuthority` is correctly trimmed to `https://yourproject.supabase.co/auth/v1`
- [ ] Log in with magic link, Google, and GitHub on staging and confirm all three succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)