### PR TITLE
BUG: Login still failed

### DIFF
--- a/ResumeSpy.Tests/HealthChecks/SupabaseAuthHealthCheckTests.cs
+++ b/ResumeSpy.Tests/HealthChecks/SupabaseAuthHealthCheckTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Moq;
+using ResumeSpy.UI.HealthChecks;
+using Xunit;
+
+namespace ResumeSpy.Tests.HealthChecks;
+
+public class SupabaseAuthHealthCheckTests
+{
+    private static IConfiguration BuildConfig(string supabaseUrl) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Supabase:Url"] = supabaseUrl
+            })
+            .Build();
+
+    private static SupabaseAuthHealthCheck BuildCheck(
+        HttpStatusCode statusCode = HttpStatusCode.OK,
+        Exception? exception = null,
+        string supabaseUrl = "https://project.supabase.co")
+    {
+        var handler = new MockHttpMessageHandler(statusCode, exception);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("SupabaseHealth"))
+               .Returns(new HttpClient(handler) { BaseAddress = null });
+
+        return new SupabaseAuthHealthCheck(factory.Object, BuildConfig(supabaseUrl));
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsHealthy_WhenOidcEndpointReturns200()
+    {
+        var check = BuildCheck(HttpStatusCode.OK);
+        var ctx = new HealthCheckContext { Registration = new HealthCheckRegistration("test", check, null, null) };
+
+        var result = await check.CheckHealthAsync(ctx);
+
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsDegraded_WhenOidcEndpointReturnsNon200()
+    {
+        var check = BuildCheck(HttpStatusCode.NotFound);
+        var ctx = new HealthCheckContext { Registration = new HealthCheckRegistration("test", check, null, null) };
+
+        var result = await check.CheckHealthAsync(ctx);
+
+        Assert.Equal(HealthStatus.Degraded, result.Status);
+        Assert.Contains("404", result.Description);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_ReturnsUnhealthy_WhenOidcEndpointIsUnreachable()
+    {
+        var check = BuildCheck(exception: new HttpRequestException("connection refused"));
+        var ctx = new HealthCheckContext { Registration = new HealthCheckRegistration("test", check, null, null) };
+
+        var result = await check.CheckHealthAsync(ctx);
+
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        Assert.NotNull(result.Exception);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_BuildsCorrectOidcUrl_FromSupabaseUrl()
+    {
+        string? capturedUrl = null;
+        var handler = new CapturingHttpMessageHandler(u => capturedUrl = u);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient("SupabaseHealth"))
+               .Returns(new HttpClient(handler));
+
+        var check = new SupabaseAuthHealthCheck(factory.Object, BuildConfig("https://abc.supabase.co/"));
+        var ctx = new HealthCheckContext { Registration = new HealthCheckRegistration("test", check, null, null) };
+
+        await check.CheckHealthAsync(ctx);
+
+        // Trailing slash on the input URL must be trimmed before /auth/v1 is appended
+        Assert.Equal("https://abc.supabase.co/auth/v1/.well-known/openid-configuration", capturedUrl);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private sealed class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly Exception? _exception;
+
+        public MockHttpMessageHandler(HttpStatusCode status = HttpStatusCode.OK, Exception? exception = null)
+        {
+            _status = status;
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_exception is not null) throw _exception;
+            return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+
+    private sealed class CapturingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Action<string> _capture;
+
+        public CapturingHttpMessageHandler(Action<string> capture) => _capture = capture;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            _capture(request.RequestUri?.ToString() ?? string.Empty);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/ResumeSpy.UI/HealthChecks/SupabaseAuthHealthCheck.cs
+++ b/ResumeSpy.UI/HealthChecks/SupabaseAuthHealthCheck.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ResumeSpy.UI.HealthChecks
+{
+    /// <summary>
+    /// Checks that our backend can reach Supabase's OIDC discovery endpoint.
+    /// A failure here means JWT validation will fail for every authenticated request.
+    /// Registered at /health/auth so ops can distinguish a Supabase connectivity
+    /// problem from an application bug.
+    /// </summary>
+    public class SupabaseAuthHealthCheck : IHealthCheck
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly string _oidcUrl;
+
+        public SupabaseAuthHealthCheck(IHttpClientFactory httpClientFactory, IConfiguration configuration)
+        {
+            _httpClientFactory = httpClientFactory;
+            var supabaseUrl = (configuration["Supabase:Url"] ?? string.Empty).TrimEnd('/');
+            _oidcUrl = $"{supabaseUrl}/auth/v1/.well-known/openid-configuration";
+        }
+
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var client = _httpClientFactory.CreateClient("SupabaseHealth");
+                var response = await client.GetAsync(_oidcUrl, cancellationToken);
+                return response.IsSuccessStatusCode
+                    ? HealthCheckResult.Healthy()
+                    : HealthCheckResult.Degraded(
+                        $"Supabase OIDC endpoint returned HTTP {(int)response.StatusCode}. " +
+                        "JWT validation may fail.");
+            }
+            catch (Exception ex)
+            {
+                return HealthCheckResult.Unhealthy(
+                    $"Cannot reach Supabase OIDC endpoint ({_oidcUrl}). " +
+                    "All authenticated requests will fail.",
+                    ex);
+            }
+        }
+    }
+}

--- a/ResumeSpy.UI/Program.cs
+++ b/ResumeSpy.UI/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.OpenApi.Models;
 using ResumeSpy.Infrastructure.Data;
 using ResumeSpy.UI.Authorization;
 using ResumeSpy.UI.Extensions;
+using ResumeSpy.UI.HealthChecks;
 using ResumeSpy.UI.Middlewares;
 using ResumeSpy.Infrastructure.Configuration;
 using ResumeSpy.Core.Entities.General;
@@ -107,15 +108,27 @@ builder.Services.RegisterService();
 // Add caching services
 builder.Services.AddMemoryCache();
 
-// Health checks: `/health` is a cheap liveness probe (no dependencies) for
-// uptime monitors, while `/health/db` runs a real `SELECT 1`-equivalent
-// against PostgreSQL so a DB outage is detected by alerting rather than by
-// failing user requests.
+// Short-lived HTTP client used exclusively by SupabaseAuthHealthCheck.
+// Kept separate from the regular IHttpClientFactory clients so a slow
+// Supabase OIDC response does not interfere with production traffic.
+builder.Services.AddHttpClient("SupabaseHealth", client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
+
+// Health checks:
+//   /health     – liveness (no dependencies)
+//   /health/db  – readiness: DB connectivity
+//   /health/auth – readiness: Supabase OIDC connectivity (JWT validation prerequisite)
 builder.Services.AddHealthChecks()
     .AddDbContextCheck<ApplicationDbContext>(
         name: "database",
         failureStatus: HealthStatus.Unhealthy,
-        tags: new[] { "db", "ready" });
+        tags: new[] { "db", "ready" })
+    .AddCheck<SupabaseAuthHealthCheck>(
+        name: "supabase-auth",
+        failureStatus: HealthStatus.Degraded,
+        tags: new[] { "auth", "ready" });
 
 // Register ILogger service
 builder.Services.AddLogging();
@@ -132,6 +145,14 @@ if (string.IsNullOrWhiteSpace(supabaseUrl))
     throw new InvalidOperationException(
         "Supabase:Url is not configured. Set the SUPABASE_URL environment variable.");
 supabaseUrl = supabaseUrl.TrimEnd('/');
+
+// Reject obviously malformed URLs (e.g. missing scheme, non-HTTP/HTTPS) before they
+// produce a cryptic "issuer mismatch" 401 at runtime.
+if (!Uri.TryCreate(supabaseUrl, UriKind.Absolute, out var supabaseUri) ||
+    supabaseUri.Scheme is not ("http" or "https"))
+    throw new InvalidOperationException(
+        $"Supabase:Url '{supabaseUrl}' is not a valid absolute URL. " +
+        "Expected format: https://<project-ref>.supabase.co");
 
 // Use the JwtBearer Authority/OIDC discovery to fetch and cache JWKS lazily.
 // The handler refreshes signing keys automatically, so Supabase JWT key
@@ -163,6 +184,47 @@ builder.Services
             ClockSkew = TimeSpan.Zero,
             NameClaimType = "sub",
             RoleClaimType = "role"
+        };
+
+        options.Events = new JwtBearerEvents
+        {
+            // Log the specific failure reason so admins can distinguish
+            // "Supabase URL wrong" (issuer mismatch) from "token expired"
+            // from "OIDC discovery endpoint unreachable" without digging into
+            // framework internals.
+            OnAuthenticationFailed = ctx =>
+            {
+                var log = ctx.HttpContext.RequestServices
+                    .GetRequiredService<ILogger<Program>>();
+                log.LogWarning(ctx.Exception,
+                    "Supabase JWT validation failed ({ExceptionType}). " +
+                    "Verify SUPABASE_URL matches your project and the JWT issuer is {Authority}.",
+                    ctx.Exception.GetType().Name,
+                    supabaseAuthority);
+                return Task.CompletedTask;
+            },
+
+            // Return a structured JSON 401 so the frontend (and developers)
+            // can tell our auth failure apart from a Supabase-side error.
+            // Supabase GoTrue errors use {"code":5xx,"error_code":...}; ours
+            // use {"succeeded":false,"error":"unauthorized","message":"..."}.
+            OnChallenge = async ctx =>
+            {
+                ctx.HandleResponse();
+                ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                ctx.Response.ContentType = "application/json";
+
+                var message = ctx.AuthenticateFailure is not null
+                    ? $"JWT validation failed: {ctx.AuthenticateFailure.Message}"
+                    : "Authentication required. Provide a valid Supabase access token.";
+
+                await ctx.Response.WriteAsJsonAsync(new
+                {
+                    succeeded = false,
+                    error = "unauthorized",
+                    message
+                });
+            }
         };
     });
 
@@ -321,6 +383,13 @@ app.MapHealthChecks("/health", new HealthCheckOptions
 app.MapHealthChecks("/health/db", new HealthCheckOptions
 {
     Predicate = check => check.Tags.Contains("db")
+}).AllowAnonymous();
+
+// Auth readiness: confirms our backend can reach Supabase's OIDC discovery
+// endpoint. Unhealthy here means JWT validation will fail for all requests.
+app.MapHealthChecks("/health/auth", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("auth")
 }).AllowAnonymous();
 
 app.Run();


### PR DESCRIPTION
Closes #53

## Root-cause analysis

The error `{"code":500,"error_code":"unexpected_failure","msg":"..."}` is Supabase GoTrue's own error format — our backend never produces it. It fires when Supabase's *internal* processing fails (SMTP not configured, OAuth redirect URL not in the allowlist, hook failure, etc.) — i.e. before our backend is involved.

However three gaps in our code made diagnosing the real culprit very hard:

| Gap | Impact |
|---|---|
| Only whitespace-checked the Supabase URL | A non-URL value (missing scheme, wrong host) passed startup but produced a silent issuer-mismatch 401 for every JWT |
| JWT challenge returned empty 401 | Client couldn't tell "our JWT config is wrong" from "Supabase rejected the login" |
| No way to test Supabase connectivity | Could not verify that our backend could even reach the OIDC endpoint |

## Changes

### `Program.cs`
- **URI format validation** — after `TrimEnd('/')`, reject non-absolute or non-HTTP/HTTPS URLs at startup so a misconfigured `SUPABASE_URL` blows up early with a clear message instead of causing cryptic 401s.
- **`JwtBearerEvents.OnAuthenticationFailed`** — logs the specific failure reason (`SecurityTokenInvalidIssuerException`, `SecurityTokenExpiredException`, `HttpRequestException` if OIDC discovery is unreachable, etc.) at Warning level.
- **`JwtBearerEvents.OnChallenge`** — returns a structured JSON 401 body `{"succeeded":false,"error":"unauthorized","message":"JWT validation failed: <reason>"}` so the frontend (and devs) can distinguish our auth failure from Supabase's `{"error_code":"unexpected_failure"}`.
- **`SupabaseHealth` named HttpClient** (5 s timeout) for health-check use only.
- **`SupabaseAuthHealthCheck` registered** + **`/health/auth` endpoint** — probes `{supabaseUrl}/auth/v1/.well-known/openid-configuration`; unhealthy means JWT validation will fail for every request.

### `ResumeSpy.UI/HealthChecks/SupabaseAuthHealthCheck.cs` (new)
Lightweight `IHealthCheck` that GETs the OIDC discovery URL and returns Healthy / Degraded / Unhealthy.

### `ResumeSpy.Tests/HealthChecks/SupabaseAuthHealthCheckTests.cs` (new)
4 unit tests covering: 200 → Healthy, non-200 → Degraded (with status code in description), exception → Unhealthy, and trailing-slash trimming on the input URL.

## Supabase-side checklist (for configuration)

If `/health/auth` reports Healthy but login still fails, the issue is on the Supabase side:
- **Email auth**: disable *Email confirmations* in Supabase Auth settings, or configure a working SMTP provider.
- **OAuth**: ensure the frontend redirect URL is in Supabase → Auth → URL Configuration → Redirect URLs.
- **Site URL**: set to the production frontend URL in Supabase Auth settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)